### PR TITLE
Adding the ability to specify a timeframe in /ah sell or /ah bid

### DIFF
--- a/src/main/java/me/badbones69/crazyauctions/Main.java
+++ b/src/main/java/me/badbones69/crazyauctions/Main.java
@@ -180,7 +180,7 @@ public class Main extends JavaPlugin implements Listener {
                     GUI.openPlayersCurrentList(player, 1);
                     return true;
                 }
-                if (args[0].equalsIgnoreCase("Sell") || args[0].equalsIgnoreCase("Bid")) {// /CA Sell/Bid <Price> [Amount of Items]
+                if (args[0].equalsIgnoreCase("Sell") || args[0].equalsIgnoreCase("Bid")) {// /CA Sell/Bid <Price> [Amount of Items] [timeframe]
                     if (!(sender instanceof Player)) {
                         sender.sendMessage(Messages.PLAYERS_ONLY.getMessage());
                         return true;
@@ -314,6 +314,21 @@ public class Main extends JavaPlugin implements Listener {
                             return true;
                         }
                         String seller = player.getName();
+
+                        //Get default timeframe
+                        String timeframe;
+                        if (args[0].equalsIgnoreCase("Bid")) {
+                            timeframe = Files.CONFIG.getFile().getString("Settings.Bid-Time");
+                        }
+                        else {
+                            timeframe = Files.CONFIG.getFile().getString("Settings.Sell-Time");
+                        }
+
+                        //If we have a timeframe specified, use that instead!
+                        if (args.length == 4) {
+                            timeframe = args[3];
+                        }
+
                         // For testing as another player
                         //String seller = "Test-Account";
                         int num = 1;
@@ -321,11 +336,9 @@ public class Main extends JavaPlugin implements Listener {
                         for (; Files.DATA.getFile().contains("Items." + num); num++) ;
                         Files.DATA.getFile().set("Items." + num + ".Price", price);
                         Files.DATA.getFile().set("Items." + num + ".Seller", seller);
-                        if (args[0].equalsIgnoreCase("Bid")) {
-                            Files.DATA.getFile().set("Items." + num + ".Time-Till-Expire", Methods.convertToMill(Files.CONFIG.getFile().getString("Settings.Bid-Time")));
-                        } else {
-                            Files.DATA.getFile().set("Items." + num + ".Time-Till-Expire", Methods.convertToMill(Files.CONFIG.getFile().getString("Settings.Sell-Time")));
-                        }
+
+                        Files.DATA.getFile().set("Items." + num + ".Time-Till-Expire", Methods.convertToMill(timeframe));
+
                         Files.DATA.getFile().set("Items." + num + ".Full-Time", Methods.convertToMill(Files.CONFIG.getFile().getString("Settings.Full-Expire-Time")));
                         int id = r.nextInt(999999);
                         // Runs 3x to check for same ID.

--- a/src/main/resources/Messages.yml
+++ b/src/main/resources/Messages.yml
@@ -39,7 +39,7 @@ Messages:
     - '&e-- &6Crazy Auctions Help &e--'
     - '&9/Ah - &eOpens the crazy auction.'
     - '&9/Ah View <Player> - &eSee what a player is selling.'
-    - '&9/Ah Sell/Bid <Price> [Amount of items] - &eList the item you are holding on the crazy auction.'
+    - '&9/Ah Sell/Bid <Price> [Amount of items] [Timeframe] - &eList the item you are holding on the crazy auction.'
     - '&9/Ah Expired/Collect - &eView and manage your canceled and expired items.'
     - '&9/Ah Listed - &eView and manage the items you are selling.'
     - '&9/Ah Help - &eView this help menu.'


### PR DESCRIPTION
This PR resolves issue #104 .

Currently this only handles the case where you specify all parameters: **/ah sell <price> [amount] [timeframe]** but does not currently handle the case of **/ah sell <price> [timeframe]**.

As an example, you can use this like:
**/ah sell 100 64 2h** -> sell a stack for $100, expiring in 2 hours
**/ah bid 10 1 15m** -> bid one item, starting at $10, expiring in 15 minutes