### PR TITLE
feat: Add Placeholder API support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,10 @@
             <id>codemc-repo</id>
             <url>https://repo.codemc.io/repository/maven-public/</url>
         </repository>
+        <repository>
+            <id>papi-repo</id>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -66,6 +70,12 @@
             <groupId>net.tnemc</groupId>
             <artifactId>Reserve</artifactId>
             <version>0.1.5.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.10.10</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/me/badbones69/crazyauctions/api/placeholders/DynamicReplacements.java
+++ b/src/main/java/me/badbones69/crazyauctions/api/placeholders/DynamicReplacements.java
@@ -1,0 +1,23 @@
+package me.badbones69.crazyauctions.api.placeholders;
+
+import org.bukkit.entity.Player;
+
+import java.util.Map;
+
+public class DynamicReplacements implements Placeholder {
+    private Map<String, String> replacements;
+
+    public DynamicReplacements(Map<String, String> replacements) {
+        this.replacements = replacements;
+    }
+
+    public String replace(Player player, String message) {
+        String output = message;
+
+        for (Map.Entry<String, String> entry : replacements.entrySet()) {
+            output = output.replace(entry.getKey(), entry.getValue());
+        }
+
+        return output;
+    }
+}

--- a/src/main/java/me/badbones69/crazyauctions/api/placeholders/Placeholder.java
+++ b/src/main/java/me/badbones69/crazyauctions/api/placeholders/Placeholder.java
@@ -1,0 +1,7 @@
+package me.badbones69.crazyauctions.api.placeholders;
+
+import org.bukkit.entity.Player;
+
+public interface Placeholder {
+    String replace(Player player, String message);
+}

--- a/src/main/java/me/badbones69/crazyauctions/api/placeholders/PlaceholderAPI.java
+++ b/src/main/java/me/badbones69/crazyauctions/api/placeholders/PlaceholderAPI.java
@@ -1,0 +1,9 @@
+package me.badbones69.crazyauctions.api.placeholders;
+
+import org.bukkit.entity.Player;
+
+public class PlaceholderAPI implements Placeholder {
+    public String replace(Player player, String message) {
+        return me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(player, message);
+    }
+}

--- a/src/main/java/me/badbones69/crazyauctions/api/placeholders/Placeholders.java
+++ b/src/main/java/me/badbones69/crazyauctions/api/placeholders/Placeholders.java
@@ -1,0 +1,88 @@
+package me.badbones69.crazyauctions.api.placeholders;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Placeholders {
+    private final List<Placeholder> placeholderList = new ArrayList<>();
+
+    private Placeholders() {
+        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            placeholderList.add(new PlaceholderAPI());
+        }
+    }
+
+    private static Placeholders instance;
+
+    public static Placeholders getInstance() {
+        if (instance == null) {
+            instance = new Placeholders();
+        }
+
+        return instance;
+    }
+
+    /**
+     * Adds a new placeholder to the list of placeholders
+     * @param placeholder
+     */
+    public void addPlaceholder(Placeholder placeholder) {
+        placeholderList.add(placeholder);
+    }
+
+    /**
+     * Runs all the placeholders for the given player and message
+     * @param player
+     * @param message
+     * @return
+     */
+    public String replace(Player player, String message) {
+        return runPlaceholders(placeholderList, player, message);
+    }
+
+    /**
+     * Runs all the placeholders for the given player and message.
+     * Allows a list of placeholders to be used for this only time
+     * which are consumed before the basic ones.
+     * @param placeholders
+     * @param player
+     * @param message
+     * @return
+     */
+    public String replace(List<Placeholder> placeholders, Player player, String message) {
+        List<Placeholder> p = new ArrayList<>(placeholders);
+        p.addAll(placeholderList);
+
+        return runPlaceholders(p, player, message);
+    }
+
+    /**
+     * Runs all the placeholders for the given player and message.
+     * Allows a placeholder to be used for this only time
+     * which is consumed before the basic ones.
+     * @param placeholder
+     * @param player
+     * @param message
+     * @return
+     */
+    public String replace(Placeholder placeholder, Player player, String message) {
+        List<Placeholder> p = new ArrayList();
+        p.add(placeholder);
+        p.addAll(placeholderList);
+
+        return runPlaceholders(p, player, message);
+    }
+
+    private String runPlaceholders(List<Placeholder> placeholders, Player player, String message) {
+        String output = message;
+
+        for (Placeholder p: placeholders) {
+            output = p.replace(player, output);
+        }
+
+        return output;
+    }
+}

--- a/src/main/java/me/badbones69/crazyauctions/api/placeholders/Placeholders.java
+++ b/src/main/java/me/badbones69/crazyauctions/api/placeholders/Placeholders.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Placeholders {
+    private static Placeholders instance;
     private final List<Placeholder> placeholderList = new ArrayList<>();
 
     private Placeholders() {
@@ -14,8 +15,6 @@ public class Placeholders {
             placeholderList.add(new PlaceholderAPI());
         }
     }
-
-    private static Placeholders instance;
 
     public static Placeholders getInstance() {
         if (instance == null) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,6 +4,7 @@ main: me.badbones69.crazyauctions.Main
 website: https://www.spigotmc.org/resources/authors/badbones69.9719/
 version: ${version}${build.number}
 depend: [Vault]
+softdepend: [PlaceholderAPI]
 api-version: 1.13
 description: A plugin to auction off items globally.
 commands:


### PR DESCRIPTION
# Feature
Include placeholders support for the lore of the items created in every GUI of the auction house.
Include softdepend on PlaceholderAPI plugin and enable them for the new placeholders format.
Refactor already existing placeholder replacements for internal values such as `%topbid%` or `%seller%` into new palceholders format.