### PR TITLE
Tax Placeholders

### DIFF
--- a/paper/src/main/java/com/badbones69/crazyauctions/controllers/GuiListener.java
+++ b/paper/src/main/java/com/badbones69/crazyauctions/controllers/GuiListener.java
@@ -657,6 +657,7 @@ public class GuiListener implements Listener {
         clickEvent.setCancelled(true);
 
         FileConfiguration config = Files.config.getConfiguration();
+
         FileConfiguration data = Files.data.getConfiguration();
 
         Player player = (Player) clickEvent.getWhoClicked();

--- a/paper/src/main/java/com/badbones69/crazyauctions/controllers/GuiListener.java
+++ b/paper/src/main/java/com/badbones69/crazyauctions/controllers/GuiListener.java
@@ -671,7 +671,7 @@ public class GuiListener implements Listener {
         ItemStack item = clickEvent.getCurrentItem();
 
         if (item == null) return;
-        
+
         if (!item.hasItemMeta()) return;
 
         if (auctionMenu.getTitle().contains(config.getString("Settings.Categories"))) {
@@ -1086,16 +1086,24 @@ public class GuiListener implements Listener {
                         return;
                     }
 
-                    cost -= (long) (cost * config.getDouble("Settings.Percent-Tax", 0) / 100);
+                    String price = String.valueOf(cost);
+
+                    long taxAmount = (long) (cost * config.getDouble("Settings.Percent-Tax", 0) / 100);
+                    cost -= taxAmount;
 
                     cost = Math.max(0, cost);
 
                     support.addMoney(Methods.getOfflinePlayer(seller), cost);
 
-                    String price = String.valueOf(cost);
+                    String tax = String.valueOf(taxAmount);
+                    String taxedPrice = String.valueOf(cost);
 
                     placeholders.put("%Price%", price);
                     placeholders.put("%price%", price);
+                    placeholders.put("%Tax%", tax);
+                    placeholders.put("%tax%", tax);
+                    placeholders.put("%Taxed_Price%", taxedPrice);
+                    placeholders.put("%taxed_price%", taxedPrice);
                     placeholders.put("%Player%", player.getName());
                     placeholders.put("%player%", player.getName());
 


### PR DESCRIPTION
Currently, when an item is purchased with Taxes enabled, the %price% placeholder is automatically replaced with the taxed price. This makes it impossible to reference the original, pre-tax price.

This PR introduces two new placeholders to resolve that issue:
- %taxed_price% – displays the final price including tax
- %tax% – displays the tax amount applied

The %price% placeholder will now continue to represent the original price set by the player.