### PR TITLE
Taxes

### DIFF
--- a/paper/src/main/java/com/badbones69/crazyauctions/Methods.java
+++ b/paper/src/main/java/com/badbones69/crazyauctions/Methods.java
@@ -250,6 +250,7 @@ public class Methods {
     }
     
     public static void updateAuction() {
+        FileConfiguration config = Files.config.getConfiguration();
         FileConfiguration data = Files.data.getConfiguration();
 
         Calendar cal = Calendar.getInstance();
@@ -284,13 +285,22 @@ public class Methods {
                         String winner = data.getString("Items." + i + ".TopBidder");
                         String seller = data.getString("Items." + i + ".Seller");
                         long price = data.getLong("Items." + i + ".Price");
+                        long taxAmount = (long) (price * config.getDouble("Settings.Percent-Tax", 0) / 100);
+                        long taxedPriceAmount = Math.max(price - taxAmount, 0);
 
-                        plugin.getSupport().addMoney(getOfflinePlayer(seller), price);
+                        plugin.getSupport().addMoney(getOfflinePlayer(seller), taxedPriceAmount);
                         plugin.getSupport().removeMoney(getOfflinePlayer(winner), price);
+
+                        String tax = String.valueOf(taxAmount);
+                        String taxedPrice = String.valueOf(taxedPriceAmount);
 
                         HashMap<String, String> placeholders = new HashMap<>();
                         placeholders.put("%Price%", getPrice(i, false));
                         placeholders.put("%price%", getPrice(i, false));
+                        placeholders.put("%Tax%", tax);
+                        placeholders.put("%tax%", tax);
+                        placeholders.put("%Taxed_Price%", taxedPrice);
+                        placeholders.put("%taxed_price%", taxedPrice);
                         placeholders.put("%Player%", winner);
                         placeholders.put("%player%", winner);
 

--- a/paper/src/main/java/com/badbones69/crazyauctions/controllers/GuiListener.java
+++ b/paper/src/main/java/com/badbones69/crazyauctions/controllers/GuiListener.java
@@ -671,7 +671,7 @@ public class GuiListener implements Listener {
         ItemStack item = clickEvent.getCurrentItem();
 
         if (item == null) return;
-        
+
         if (!item.hasItemMeta()) return;
 
         if (auctionMenu.getTitle().contains(config.getString("Settings.Categories"))) {
@@ -1086,16 +1086,24 @@ public class GuiListener implements Listener {
                         return;
                     }
 
-                    cost -= (long) (cost * config.getDouble("Settings.Percent-Tax", 0) / 100);
+                    String price = String.valueOf(cost);
+
+                    long taxAmount = (long) (cost * config.getDouble("Settings.Percent-Tax", 0) / 100);
+                    cost -= taxAmount;
 
                     cost = Math.max(0, cost);
 
                     support.addMoney(Methods.getOfflinePlayer(seller), cost);
 
-                    String price = String.valueOf(cost);
+                    String tax = String.valueOf(taxAmount);
+                    String taxedPrice = String.valueOf(cost);
 
                     placeholders.put("%Price%", price);
                     placeholders.put("%price%", price);
+                    placeholders.put("%Tax%", tax);
+                    placeholders.put("%tax%", tax);
+                    placeholders.put("%Taxed_Price%", taxedPrice);
+                    placeholders.put("%taxed_price%", taxedPrice);
                     placeholders.put("%Player%", player.getName());
                     placeholders.put("%player%", player.getName());
 


### PR DESCRIPTION
Currently, when an item is purchased with Taxes enabled, the %price% placeholder is automatically replaced with the taxed price. This makes it impossible to reference the original, pre-tax price.

This PR introduces two new placeholders to resolve that issue:

%taxed_price% – displays the final price including tax
%tax% – displays the tax amount applied
The %price% placeholder will now continue to represent the original price set by the player.

I additionally added the taxes including the placeholders, when a bidding is won.