### PR TITLE
Fix players being unable to buy other players' listings

### DIFF
--- a/common/src/main/java/com/badbones69/crazyauctions/common/storage/impl/file/types/YamlFactory.java
+++ b/common/src/main/java/com/badbones69/crazyauctions/common/storage/impl/file/types/YamlFactory.java
@@ -17,6 +17,9 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ItemType;
 import org.jspecify.annotations.NonNull;
 import us.crazycrew.api.enums.ShopType;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 public class YamlFactory extends FlatFactory {
@@ -130,6 +133,50 @@ public class YamlFactory extends FlatFactory {
                 }
             }
         }
+
+        repairStoreIDs();
+    }
+
+    /**
+     * Gives every listing an id that no other listing shares.
+     *
+     * <p>The id of an expired item used to be copied over as a number, which came out as 0 for
+     * every entry and left the menus unable to tell those listings apart.
+     */
+    private void repairStoreIDs() {
+        final Set<String> ids = new HashSet<>();
+
+        boolean isSaving = false;
+
+        for (final String path : List.of("Items", "OutOfTime/Cancelled")) {
+            final ConfigurationSection section = this.configuration.getConfigurationSection(path);
+
+            if (section == null) continue;
+
+            for (final String key : section.getKeys(false)) {
+                final ConfigurationSection listing = section.getConfigurationSection(key);
+
+                if (listing == null) continue;
+
+                final String id = listing.getString("StoreID", "");
+
+                if (!id.isBlank() && ids.add(id)) continue;
+
+                String replacement;
+
+                do {
+                    replacement = UUID.randomUUID().toString().substring(0, 8);
+                } while (!ids.add(replacement));
+
+                listing.set("StoreID", replacement);
+
+                isSaving = true;
+            }
+        }
+
+        if (isSaving) {
+            FileKeys.data.save();
+        }
     }
 
     @Override
@@ -176,7 +223,7 @@ public class YamlFactory extends FlatFactory {
             }
         }
 
-        item.set("StoreID", UUID.randomUUID().toString().substring(0, 8));
+        item.set("StoreID", getStoreID(section));
 
         item.set("Full-Time", TimeUtils.convertToMill(config.getString("Settings.Full-Expire-Time", "10d")));
 
@@ -188,6 +235,41 @@ public class YamlFactory extends FlatFactory {
         item.set("Item", base64);
 
         FileKeys.data.save();
+    }
+
+    /**
+     * Builds an id that is not in use by another listing.
+     *
+     * <p>The menus resolve a clicked item back to its listing by this id, so a duplicate would
+     * hand the buyer someone else's item.
+     *
+     * @param items The section holding the currently listed items.
+     * @return An id no other listing is using.
+     */
+    private String getStoreID(@NonNull final ConfigurationSection items) {
+        final ConfigurationSection expired = this.configuration.getConfigurationSection("OutOfTime/Cancelled");
+
+        String id;
+
+        do {
+            id = UUID.randomUUID().toString().substring(0, 8);
+        } while (isTaken(items, id) || (expired != null && isTaken(expired, id)));
+
+        return id;
+    }
+
+    private boolean isTaken(@NonNull final ConfigurationSection section, @NonNull final String id) {
+        for (final String key : section.getKeys(false)) {
+            final ConfigurationSection listing = section.getConfigurationSection(key);
+
+            if (listing == null) continue;
+
+            if (id.equals(listing.getString("StoreID", key))) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     @Override

--- a/paper/src/main/java/com/badbones69/crazyauctions/Methods.java
+++ b/paper/src/main/java/com/badbones69/crazyauctions/Methods.java
@@ -82,8 +82,8 @@ public class Methods {
         return false;
     }
     
-    public static List<ItemStack> getPage(List<ItemStack> list, Integer page) {
-        List<ItemStack> items = new ArrayList<>();
+    public static <T> List<T> getPage(List<T> list, Integer page) {
+        List<T> items = new ArrayList<>();
 
         if (page <= 0) page = 1;
 
@@ -106,34 +106,7 @@ public class Methods {
 
         return items;
     }
-    
-    public static List<Integer> getPageInts(List<Integer> list, Integer page) {
-        List<Integer> items = new ArrayList<>();
 
-        if (page <= 0) page = 1;
-
-        int max = 45;
-        int index = page * max - max;
-        int endIndex = index >= list.size() ? list.size() - 1 : index + max;
-
-        for (; index < endIndex; index++) {
-            if (index < list.size()) items.add(list.get(index));
-        }
-
-        for (; items.isEmpty(); page--) {
-            if (page <= 0) break;
-
-            index = page * max - max;
-            endIndex = index >= list.size() ? list.size() - 1 : index + max;
-
-            for (; index < endIndex; index++) {
-                if (index < list.size()) items.add(list.get(index));
-            }
-        }
-
-        return items;
-    }
-    
     public static int getMaxPage(List<ItemStack> list) {
         int maxPage = 1;
         int amount = list.size();
@@ -252,7 +225,7 @@ public class Methods {
 
                         data.set("OutOfTime/Cancelled." + num + ".Seller", winner);
                         data.set("OutOfTime/Cancelled." + num + ".Full-Time", fullExpireTime.getTimeInMillis());
-                        data.set("OutOfTime/Cancelled." + num + ".StoreID", data.getInt("Items." + i + ".StoreID"));
+                        data.set("OutOfTime/Cancelled." + num + ".StoreID", getStoreID(data, "Items." + i));
                         data.set("OutOfTime/Cancelled." + num + ".Item", data.getString("Items." + i + ".Item"));
                     } else {
                         String seller = data.getString("Items." + i + ".Seller");
@@ -267,7 +240,7 @@ public class Methods {
 
                         data.set("OutOfTime/Cancelled." + num + ".Seller", data.getString("Items." + i + ".Seller"));
                         data.set("OutOfTime/Cancelled." + num + ".Full-Time", fullExpireTime.getTimeInMillis());
-                        data.set("OutOfTime/Cancelled." + num + ".StoreID", data.getInt("Items." + i + ".StoreID"));
+                        data.set("OutOfTime/Cancelled." + num + ".StoreID", getStoreID(data, "Items." + i));
                         data.set("OutOfTime/Cancelled." + num + ".Item", data.getString("Items." + i + ".Item"));
                     }
 
@@ -280,6 +253,20 @@ public class Methods {
         if (shouldSave) FileKeys.data.save();
     }
     
+    /**
+     * Reads the id a listing is identified by in the menus.
+     *
+     * <p>It is saved as a string, but older data files may have it saved as a number and some
+     * entries may not have it at all, so the section the listing lives in is used as a fallback.
+     *
+     * @param data The file in which the data is saved.
+     * @param path The section the listing is saved in. i.e. Items.1
+     * @return The id of the listing.
+     */
+    public static String getStoreID(FileConfiguration data, String path) {
+        return data.getString(path + ".StoreID", path.substring(path.lastIndexOf('.') + 1));
+    }
+
     public static long getPrice(String ID, Boolean Expired) {
         long price = 0;
 
@@ -315,7 +302,7 @@ public class Methods {
 
         data.set("OutOfTime/Cancelled." + num + ".Seller", data.getString("Items." + i + ".Seller"));
         data.set("OutOfTime/Cancelled." + num + ".Full-Time", data.getLong("Items." + i + ".Full-Time"));
-        data.set("OutOfTime/Cancelled." + num + ".StoreID", data.getInt("Items." + i + ".StoreID"));
+        data.set("OutOfTime/Cancelled." + num + ".StoreID", getStoreID(data, "Items." + i));
         data.set("OutOfTime/Cancelled." + num + ".Item", data.getString("Items." + i + ".Item"));
 
         data.set("Items." + i, null);

--- a/paper/src/main/java/com/badbones69/crazyauctions/controllers/GuiListener.java
+++ b/paper/src/main/java/com/badbones69/crazyauctions/controllers/GuiListener.java
@@ -54,7 +54,7 @@ public class GuiListener implements Listener {
     private static final Map<UUID, String> biddingID = new HashMap<>();
     private static final Map<UUID, ShopType> shopType = new HashMap<>(); // Shop Type
     private static final Map<UUID, Category> shopCategory = new HashMap<>(); // Category Type
-    private static final Map<UUID, List<Integer>> List = new HashMap<>();
+    private static final Map<UUID, List<String>> List = new HashMap<>();
     private static final Map<UUID, String> IDs = new HashMap<>();
 
     public static void openShop(@NotNull Player player, @NotNull ShopType sell, @NotNull Category cat, int page) {
@@ -63,7 +63,7 @@ public class GuiListener implements Listener {
         YamlConfiguration config = FileKeys.config.getConfiguration();
         YamlConfiguration data = FileKeys.data.getConfiguration();
         List<ItemStack> items = new ArrayList<>();
-        List<Integer> ID = new ArrayList<>();
+        List<String> ID = new ArrayList<>();
 
         if (!data.contains("Items")) {
             data.set("Items.Clear", null);
@@ -103,7 +103,7 @@ public class GuiListener implements Listener {
 
                             items.add(itemBuilder.build());
 
-                            ID.add(data.getInt("Items." + i + ".StoreID"));
+                            ID.add(Methods.getStoreID(data, "Items." + i));
                         }
                     } else {
                         if (sell == ShopType.SELL) {
@@ -123,7 +123,7 @@ public class GuiListener implements Listener {
 
                             items.add(itemBuilder.build());
 
-                            ID.add(data.getInt("Items." + i + ".StoreID"));
+                            ID.add(Methods.getStoreID(data, "Items." + i));
                         }
                     }
                 }
@@ -194,13 +194,13 @@ public class GuiListener implements Listener {
         setPage(inv, page, items, ID, player);
     }
 
-    private static void setPage(Inventory inv, int page, List<ItemStack> items, List<Integer> ID, Player player) {
+    private static void setPage(Inventory inv, int page, List<ItemStack> items, List<String> ID, Player player) {
         for (ItemStack item : Methods.getPage(items, page)) {
             int slot = inv.firstEmpty();
 
             inv.setItem(slot, item);
         }
-        List<Integer> Id = new ArrayList<>(Methods.getPageInts(ID, page));
+        List<String> Id = new ArrayList<>(Methods.getPage(ID, page));
         List.put(player.getUniqueId(), Id);
 
         player.openInventory(inv);
@@ -256,7 +256,7 @@ public class GuiListener implements Listener {
         YamlConfiguration data = FileKeys.data.getConfiguration();
 
         List<ItemStack> items = new ArrayList<>();
-        List<Integer> ID = new ArrayList<>();
+        List<String> ID = new ArrayList<>();
 
         Inventory inv = new AuctionMenu(54, Methods.color(config.getString("Settings.Players-Current-Items"))).getInventory();
 
@@ -289,7 +289,7 @@ public class GuiListener implements Listener {
 
                     items.add(itemBuilder.build());
 
-                    ID.add(data.getInt("Items." + i + ".StoreID"));
+                    ID.add(Methods.getStoreID(data, "Items." + i));
                 }
             }
         }
@@ -304,7 +304,7 @@ public class GuiListener implements Listener {
         YamlConfiguration data = FileKeys.data.getConfiguration();
 
         List<ItemStack> items = new ArrayList<>();
-        List<Integer> ID = new ArrayList<>();
+        List<String> ID = new ArrayList<>();
 
         if (data.contains("OutOfTime/Cancelled")) {
             for (String i : data.getConfigurationSection("OutOfTime/Cancelled").getKeys(false)) {
@@ -328,7 +328,7 @@ public class GuiListener implements Listener {
 
                         items.add(itemBuilder.build());
 
-                        ID.add(data.getInt("OutOfTime/Cancelled." + i + ".StoreID"));
+                        ID.add(Methods.getStoreID(data, "OutOfTime/Cancelled." + i));
                     }
                 }
             }
@@ -404,7 +404,7 @@ public class GuiListener implements Listener {
         String price = StringUtils.formatNumber(Methods.getPrice(ID, false));
         String time = Methods.convertToTime(data.getLong("Items." + ID + ".Time-Till-Expire"));
 
-        String sellerName = data.getString("Items." + ID + ".Seller", "N/A");
+        String sellerName = data.getString("Items." + ID + ".SellerName", "N/A");
 
         ItemBuilder itemBuilder = ItemBuilder.convertItemStack(data.getString("Items." + ID + ".Item"));
 
@@ -470,7 +470,7 @@ public class GuiListener implements Listener {
         YamlConfiguration data = FileKeys.data.getConfiguration();
 
         List<ItemStack> items = new ArrayList<>();
-        List<Integer> ID = new ArrayList<>();
+        List<String> ID = new ArrayList<>();
 
         final UUID uuid = player.getUniqueId();
         final String asString = uuid.toString();
@@ -521,7 +521,7 @@ public class GuiListener implements Listener {
 
                     items.add(itemBuilder.build());
 
-                    ID.add(data.getInt("Items." + i + ".StoreID"));
+                    ID.add(Methods.getStoreID(data, "Items." + i));
                 }
             }
         }
@@ -896,14 +896,14 @@ public class GuiListener implements Listener {
             }
 
             if (List.containsKey(player.getUniqueId())) {
-                if (List.get(player.getUniqueId()).size() >= slot) {
-                    int id = List.get(player.getUniqueId()).get(slot);
+                if (List.get(player.getUniqueId()).size() > slot) {
+                    String id = List.get(player.getUniqueId()).get(slot);
 
                     if (data.contains("Items")) {
                         for (String i : data.getConfigurationSection("Items").getKeys(false)) {
-                            int ID = data.getInt("Items." + i + ".StoreID");
+                            String ID = Methods.getStoreID(data, "Items." + i);
 
-                            if (id == ID) {
+                            if (id.equals(ID)) {
                                 if (Permissions.admin_wildcard.hasPermission(player) || Permissions.force_end.hasPermission(player)) {
                                     if (clickEvent.getAction() == InventoryAction.MOVE_TO_OTHER_INVENTORY) {
 
@@ -1162,13 +1162,16 @@ public class GuiListener implements Listener {
             }
 
             if (List.containsKey(player.getUniqueId())) {
-                if (List.get(player.getUniqueId()).size() >= slot) {
-                    int id = List.get(player.getUniqueId()).get(slot);
+                if (List.get(player.getUniqueId()).size() > slot) {
+                    String id = List.get(player.getUniqueId()).get(slot);
 
                     if (data.contains("Items")) {
                         for (String i : data.getConfigurationSection("Items").getKeys(false)) {
-                            int ID = data.getInt("Items." + i + ".StoreID");
-                            if (id == ID) {
+                            String ID = Methods.getStoreID(data, "Items." + i);
+
+                            if (id.equals(ID)) {
+                                if (!Objects.equals(data.getString("Items." + i + ".Seller"), player.getUniqueId().toString())) continue;
+
                                 Messages.cancelled_item.sendMessage(player);
 
                                 Methods.expireItem(1, player, i, data, Reasons.PLAYER_FORCE_CANCEL);
@@ -1271,14 +1274,16 @@ public class GuiListener implements Listener {
             }
 
             if (List.containsKey(player.getUniqueId())) {
-                if (List.get(player.getUniqueId()).size() >= slot) {
-                    int id = List.get(player.getUniqueId()).get(slot);
+                if (List.get(player.getUniqueId()).size() > slot) {
+                    String id = List.get(player.getUniqueId()).get(slot);
 
                     if (data.contains("OutOfTime/Cancelled")) {
                         for (String i : data.getConfigurationSection("OutOfTime/Cancelled").getKeys(false)) {
-                            int ID = data.getInt("OutOfTime/Cancelled." + i + ".StoreID");
+                            String ID = Methods.getStoreID(data, "OutOfTime/Cancelled." + i);
 
-                            if (id == ID) {
+                            if (id.equals(ID)) {
+                                if (!Objects.equals(data.getString("OutOfTime/Cancelled." + i + ".Seller"), player.getUniqueId().toString())) continue;
+
                                 if (!Methods.isInvFull(player)) {
                                     Messages.got_item_back.sendMessage(player);
 


### PR DESCRIPTION
## The problem

On a live server with listings from several players, clicking someone else's item in the
auction either tells the buyer it is their own item, or sells them a listing they never
clicked on. Both selling and bidding menus are affected, as are the expired/cancelled and
"your listings" menus.

## Root cause

`YamlFactory#addItem` writes the listing id as a string:

```java
item.set("StoreID", UUID.randomUUID().toString().substring(0, 8)); // "a3f9b2c1"
```

Every read of that field goes through `getInt`, in 11 places across `GuiListener` and
`Methods`:

```java
int ID = data.getInt("Items." + i + ".StoreID");
```

`MemorySection#getInt` returns the default `0` for anything that is not a `Number`, so
**every listing reports id 0**. The menus resolve a click by scanning for the first listing
with a matching id (`GuiListener#onInvClick`), which therefore always lands on the first
entry in `data.yml`, whatever was clicked. When that first entry belongs to the clicking
player, they get the "your item" barrier; otherwise they buy the wrong listing.

The same `getInt` is used when a listing is moved to `OutOfTime/Cancelled`, so every
expired entry already on disk has `StoreID: 0` written as an actual number.

This has been present since the storage layer was split into `common` in 26.1.2 вЂ” the
writer moved to `YamlFactory` while the readers stayed behind in `paper`, and nothing ties
the two ends of the contract together.

## Changes

* `Methods#getStoreID` reads the id as a string, falling back to the section key, so data
  files written by older versions (numeric ids) and entries with no id at all still
  resolve. All 11 call sites now go through it.
* Moving a listing to the expired section no longer collapses its id to `0`.
* `YamlFactory#addItem` allocates an id that no other listing in either section holds,
  instead of assuming a random 8 char id is unique.
* `YamlFactory#repairStoreIDs` runs on startup and gives a unique id to any listing whose
  id is missing or duplicated, which repairs the `StoreID: 0` entries already on disk. It
  is idempotent and only saves when it actually changed something.
* Returning an expired listing now checks the seller first. The lookup walked *every*
  entry in `OutOfTime/Cancelled` with no ownership check, so with the broken ids a player
  clicking their own expired item received the first expired item on the server вЂ”
  someone else's. Cancelling an active listing got the same check.
* `List.get(uuid).size() >= slot` в†’ `> slot`. On a full page (45 listings) the old bound
  threw `IndexOutOfBoundsException` for slot 45.
* The purchase confirmation menu showed the seller's uuid instead of their name
  (`.Seller` в†’ `.SellerName`).
* `Methods#getPage` and `Methods#getPageInts` were identical bodies; folded into one
  generic method.

## Compatibility

No config or data format change. Active listings written by 26.1.2 already carry proper
unique string ids and resolve correctly as soon as this is applied; expired entries are
repaired on the first startup. Servers should still back up `data.yml` before updating,
since the repair rewrites the file.

## Verification

`./gradlew assemble` passes. Beyond that I ran the read/write paths against a real
`YamlConfiguration` (paper-api 26.1.2) covering: reproduction of the original mis-resolve,
correct resolution after the fix, legacy numeric ids, missing ids falling back to the
section key, repair of a `StoreID: 0` data file plus its idempotency, uniqueness of newly
allocated ids, a YAML save/load round trip including an all-digit id, and item/id alignment
across pages. All pass.
